### PR TITLE
LLM-assisted Graph-Merging - Step 1 - data-only LLM input prep for node comparisons

### DIFF
--- a/docs/LLM_Assisted_Graph_Merging_Step1.md
+++ b/docs/LLM_Assisted_Graph_Merging_Step1.md
@@ -1,55 +1,57 @@
 ### LLM-Assisted Graph Merging — Step 1: Prepare Inputs for the LLM
 
 This document explains how the Step 1 code prepares compact, data-only inputs
-for LLM comparisons between two nodes (and lays the groundwork for edges later).
+for LLM comparisons between nodes and edges.
 It focuses solely on preparing the data; there are no prompts, LLM calls, or merge actions here.
 
 
 ## Goals (Step 1)
-- Provide the LLM enough context to decide if two nodes should be merged.
+- Provide the LLM enough context to decide if two or more nodes should be merged.
 - Data included per comparison:
-  - Node text (surface form)
+  - Node merged_text (current short title; raw node text if no merge yet)
   - Aliases / alternate names
   - Context / reasoning (why the node exists): node notes + rationales from linked edges
-  - Source metadata (paper_id, with optional fields reserved for title/section/paragraph)
+  - Provenance / merge history as `merged_sources` (per-source records with paper_id, optional doi/title/section/paragraph_id, original text, and lightweight context)
   - Linked edges (immediate connections with type, rationale, confidence, and source)
-  - Immediate neighbor nodes (A.IN1+ and B.IN1+) as lightweight summaries (name/aliases only)
+  - Immediate neighbor nodes (A.IN1+ and B.IN1+) as summaries including name, aliases, and lightweight context (neighbor notes + linked-edge rationales)
 
 
 ## Files Overview
 - `src/merge_types.py`
   - `SourceMetadata`: identifies where a node/edge came from (currently `paper_id` from the output filename; placeholders for `title`, `section`, `paragraph_id`).
   - `LinkedEdgeSummary`: short record of an immediate connection (edge type, rationale, confidence, and source).
-  - `NodeAggregate`: collected per-node data from all occurrences across outputs. Adds `neighbor_node_keys` and `attributes_by_source` (array entries per paper/DOI) to enable provenance-aware, recursive merges.
-  - `NodeViewForComparison`: the per-node view handed to the LLM later (text, aliases, context, sources, linked edges, and `neighbors`).
+  - `NodeAggregate`: collected per-node data from all occurrences across outputs. Adds `neighbor_node_keys`, `merged_text`, and `merged_sources` (array entries per paper/raw node) to enable provenance-aware, recursive merges.
+  - `NodeViewForComparison`: the per-node view handed to the LLM later (`merged_text`, aliases, context, linked edges, `neighbors` including context, and full `merged_sources` for merge history).
   - `NodeComparisonInput`: a pair of `NodeViewForComparison` (data-only) for A vs B.
-  - Edge types (`EdgeViewForComparison`, `EdgeComparisonInput`) are defined for a later step.
+  - `NodeSetComparisonInput`: an N-way comparison payload carrying a list of `NodeViewForComparison`.
+  - Edge types include `EdgeViewForComparison` (which now includes `merged_sources`) for a later step.
 
 - `src/merge_indexer.py`
   - `build_merge_index(output_dir)`: reads parsed `OutputSchema` JSON files from `output/`, aggregates nodes by canonical name (lowercased), merges aliases and notes, and collects linked edge rationales as context.
   - Produces `MergeIndex` with `nodes: Dict[node_key, NodeAggregate]`.
-  - Populates `neighbor_node_keys` by co-occurrence within the same paper (all targets in a paper are considered 1-hop neighbors of each other). Only node IDs are recorded; no neighbor edges are pulled.
-  - Fills `attributes_by_source` with one entry per paper holding node attributes (text, canonical_text, aliases, notes, confidence) alongside `paper_id` and optional `doi`.
-  - Aggregates edges into `edges: Dict[edge_type, EdgeAggregate]`, also with `attributes_by_source` per paper (node_pairs, rationales, confidence_samples) for recursive merging and provenance-aware edge analysis.
+  - Populates `neighbor_node_keys` by co-occurrence within the same paper (all targets in a paper are considered 1-hop neighbors of each other). Only neighbor node keys are recorded; no neighbor edges are pulled.
+  - Fills `merged_sources` with one entry per paper holding node attributes (text, canonical_text, aliases, notes, confidence, optional `title/section/paragraph_id`, and lightweight `context`).
+  - Aggregates edges into `edges: Dict[edge_type, EdgeAggregate]`, also with `merged_sources` per paper (node_pairs, rationales, confidence_samples, optional `title/section/paragraph_id`) for recursive merging and provenance-aware edge analysis.
 
 - `src/merge_input_builder.py`
-  - `build_node_comparison_input(index, key_a, key_b)`: converts two aggregates to a data-only `NodeComparisonInput`.
+  - `build_node_comparison_input(index, key_a, key_b)`: converts two aggregates to a data-only `NodeComparisonInput` (pairwise mode).
+  - `build_node_set_comparison_input(index, keys)`: converts N aggregates to a data-only `NodeSetComparisonInput` (N-way mode).
   - The node view includes:
-    - `text`, `aliases`
+    - `merged_text`, `aliases`
     - `context` (node notes + "[EDGE_TYPE] rationale" for immediate connections)
-    - `source_metadata`
     - `linked_edges`
-    - `neighbors` (A.IN1+/B.IN1+ summaries, no edges)
+    - `neighbors` (A.IN1+/B.IN1+ summaries, including neighbor context)
+    - `merged_sources` (per-paper/raw-node attributes and context)
 
 - `examples/walkthrough_prepare_llm_input.py`
-  - Runnable script demonstrating the end-to-end Step 1 flow.
+  - Runnable script demonstrating the end-to-end Step 1 flow. Supports pairwise and N-way modes.
 
 
 ## How Requirements Are Met
-- Node text: `NodeViewForComparison.text`
+- Node text: `NodeViewForComparison.merged_text`
 - Aliases: `NodeViewForComparison.aliases`
 - Context / reasoning: `NodeViewForComparison.context` combines node notes with connected edge rationales.
-- Source metadata: `NodeViewForComparison.source_metadata` is a list of `SourceMetadata` (currently `paper_id`; placeholders for title/section/paragraph).
+- Provenance / merge history: `NodeViewForComparison.merged_sources` carries per-paper/raw-node attributes and context.
 - Linked edges: `NodeViewForComparison.linked_edges` contains `LinkedEdgeSummary` for each immediate connection.
 
 There is deliberately no prompt or instruction text in Step 1. This is data-only.
@@ -62,12 +64,13 @@ uv run python examples/walkthrough_prepare_llm_input.py --list --limit 10
 uv run python examples/walkthrough_prepare_llm_input.py
 uv run python examples/walkthrough_prepare_llm_input.py --key-a <node_key_a> --key-b <node_key_b>
 uv run python examples/walkthrough_prepare_llm_input.py --save output/node_comparison_example.json
+# N-way comparison (provide any number of keys)
+uv run python examples/walkthrough_prepare_llm_input.py --keys <key1> <key2> <key3> <key4>
 ```
 
 The printed (or saved) JSON is the exact payload you can provide to an LLM in Step 2.
 
 
-## How This Enables Step 2 (Preview Only)
-- Candidate selection can embed `NodeAggregate` fields (canonical name, text, aliases, top-k notes) and return top-N similar `node_key` pairs.
-- LLM evaluation consumes `NodeComparisonInput` and returns MERGE vs KEEP SEPARATE with a reason (Step 2.2, not implemented here).
+## How This Enables Step 2
+- Candidate selection can embed `NodeAggregate` fields (canonical name, merged_text, aliases, top-k notes) and return top-N similar `node_key` pairs or sets.
 - Merge execution uses stable `node_key`s to unify aliases/notes and repoint edges.

--- a/docs/LLM_Assisted_Graph_Merging_Step1.md
+++ b/docs/LLM_Assisted_Graph_Merging_Step1.md
@@ -10,8 +10,7 @@ It focuses solely on preparing the data; there are no prompts, LLM calls, or mer
 - Data included per comparison:
   - Node text (surface form)
   - Aliases / alternate names
-  - Context / reasoning (why the nod# Ensure project root is on sys.path so `src` is importable when running from repo root
-e exists): node notes + rationales from linked edges
+  - Context / reasoning (why the node exists): node notes + rationales from linked edges
   - Source metadata (paper_id, with optional fields reserved for title/section/paragraph)
   - Linked edges (immediate connections with type, rationale, confidence, and source)
 

--- a/docs/LLM_Assisted_Graph_Merging_Step1.md
+++ b/docs/LLM_Assisted_Graph_Merging_Step1.md
@@ -1,0 +1,69 @@
+### LLM-Assisted Graph Merging — Step 1: Prepare Inputs for the LLM
+
+This document explains how the Step 1 code prepares compact, data-only inputs
+for LLM comparisons between two nodes (and lays the groundwork for edges later).
+It focuses solely on preparing the data; there are no prompts, LLM calls, or merge actions here.
+
+
+## Goals (Step 1)
+- Provide the LLM enough context to decide if two nodes should be merged.
+- Data included per comparison:
+  - Node text (surface form)
+  - Aliases / alternate names
+  - Context / reasoning (why the nod# Ensure project root is on sys.path so `src` is importable when running from repo root
+e exists): node notes + rationales from linked edges
+  - Source metadata (paper_id, with optional fields reserved for title/section/paragraph)
+  - Linked edges (immediate connections with type, rationale, confidence, and source)
+
+
+## Files Overview
+- `src/merge_types.py`
+  - `SourceMetadata`: identifies where a node/edge came from (currently `paper_id` from the output filename; placeholders for `title`, `section`, `paragraph_id`).
+  - `LinkedEdgeSummary`: short record of an immediate connection (edge type, rationale, confidence, and source).
+  - `NodeAggregate`: collected per-node data from all occurrences across outputs.
+  - `NodeViewForComparison`: the per-node view handed to the LLM later (text, aliases, context, sources, linked edges).
+  - `NodeComparisonInput`: a pair of `NodeViewForComparison` (data-only) for A vs B.
+  - Edge types (`EdgeViewForComparison`, `EdgeComparisonInput`) are defined for a later step.
+
+- `src/merge_indexer.py`
+  - `build_merge_index(output_dir)`: reads parsed `OutputSchema` JSON files from `output/`, aggregates nodes by canonical name (lowercased), merges aliases and notes, and collects linked edge rationales as context.
+  - Produces `MergeIndex` with `nodes: Dict[node_key, NodeAggregate]`.
+
+- `src/merge_input_builder.py`
+  - `build_node_comparison_input(index, key_a, key_b)`: converts two aggregates to a data-only `NodeComparisonInput`.
+  - The node view includes:
+    - `text`, `aliases`
+    - `context` (node notes + "[EDGE_TYPE] rationale" for immediate connections)
+    - `source_metadata`
+    - `linked_edges`
+
+- `examples/walkthrough_prepare_llm_input.py`
+  - Runnable script demonstrating the end-to-end Step 1 flow.
+
+
+## How Requirements Are Met
+- Node text: `NodeViewForComparison.text`
+- Aliases: `NodeViewForComparison.aliases`
+- Context / reasoning: `NodeViewForComparison.context` combines node notes with connected edge rationales.
+- Source metadata: `NodeViewForComparison.source_metadata` is a list of `SourceMetadata` (currently `paper_id`; placeholders for title/section/paragraph).
+- Linked edges: `NodeViewForComparison.linked_edges` contains `LinkedEdgeSummary` for each immediate connection.
+
+There is deliberately no prompt or instruction text in Step 1. This is data-only.
+
+
+## Walkthrough
+- List available node keys and build a comparison payload:
+```bash
+uv run python examples/walkthrough_prepare_llm_input.py --list --limit 10
+uv run python examples/walkthrough_prepare_llm_input.py
+uv run python examples/walkthrough_prepare_llm_input.py --key-a <node_key_a> --key-b <node_key_b>
+uv run python examples/walkthrough_prepare_llm_input.py --save output/node_comparison_example.json
+```
+
+The printed (or saved) JSON is the exact payload you can provide to an LLM in Step 2.
+
+
+## How This Enables Step 2 (Preview Only)
+- Candidate selection can embed `NodeAggregate` fields (canonical name, text, aliases, top-k notes) and return top-N similar `node_key` pairs.
+- LLM evaluation consumes `NodeComparisonInput` and returns MERGE vs KEEP SEPARATE with a reason (Step 2.2, not implemented here).
+- Merge execution uses stable `node_key`s to unify aliases/notes and repoint edges.

--- a/examples/walkthrough_prepare_llm_input.py
+++ b/examples/walkthrough_prepare_llm_input.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Walkthrough: Prepare data-only LLM inputs for node comparison (Step 1)
+This script demonstrates how to:
+1) Read structured extraction outputs from the `output/` directory
+2) Build an in-memory merge index of nodes with aliases, context, and sources
+3) Produce a data-only payload for comparing two nodes (no prompt text)
+Usage examples:
+  uv run python examples/walkthrough_prepare_llm_input.py
+  uv run python examples/walkthrough_prepare_llm_input.py --key-a <node_key_a> --key-b <node_key_b>
+  uv run python examples/walkthrough_prepare_llm_input.py --save output/node_comparison_example.json
+The resulting payload contains exactly the fields required for LLM-assisted merge decisions,
+without including any task instructions.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+import sys
+
+# Ensure project root is on sys.path so `src` is importable when running from repo root
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.merge_indexer import build_merge_index  # noqa: E402
+from src.merge_input_builder import build_node_comparison_input  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a data-only comparison payload for two nodes from extraction outputs.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output"),
+        help="Directory containing structured OutputSchema JSON files (not raw responses).",
+    )
+    parser.add_argument(
+        "--key-a",
+        type=str,
+        default=None,
+        help="Node key for the first node (defaults to the first key found).",
+    )
+    parser.add_argument(
+        "--key-b",
+        type=str,
+        default=None,
+        help="Node key for the second node (defaults to the second key found).",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List the first N available node keys and exit.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="How many keys to list when using --list.",
+    )
+    parser.add_argument(
+        "--save",
+        type=Path,
+        default=None,
+        help="Optional path to save the generated comparison payload as JSON.",
+    )
+    return parser.parse_args()
+
+
+def select_keys(
+    index_keys: list[str], key_a: Optional[str], key_b: Optional[str]
+) -> tuple[str, str]:
+    if key_a and key_b:
+        return key_a, key_b
+    if len(index_keys) < 2:
+        raise RuntimeError("Need at least two nodes to build a comparison payload.")
+    return index_keys[0], index_keys[1]
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.output_dir.exists():
+        raise FileNotFoundError(
+            f"Output directory not found: {args.output_dir}. Run the extractor first."
+        )
+
+    index = build_merge_index(args.output_dir)
+    node_keys = list(index.nodes.keys())
+
+    if args.list:
+        print(f"Total nodes: {len(node_keys)}")
+        print("First keys:")
+        for k in node_keys[: max(0, args.limit)]:
+            print(f" - {k}")
+        return
+
+    key_a, key_b = select_keys(node_keys, args.key_a, args.key_b)
+
+    payload = build_node_comparison_input(index, key_a, key_b)
+    payload_json = payload.model_dump_json(indent=2)
+
+    print(f"Total nodes indexed: {len(node_keys)}")
+    print(f"Node A key: {key_a}")
+    print(f"Node B key: {key_b}")
+    print("\nData-only comparison payload:\n")
+    print(payload_json)
+
+    if args.save is not None:
+        args.save.parent.mkdir(parents=True, exist_ok=True)
+        with args.save.open("w", encoding="utf-8") as fh:
+            fh.write(payload_json)
+        print(f"\nSaved payload to: {args.save}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/merge_indexer.py
+++ b/src/merge_indexer.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, Field
 from .prompts import OutputSchema
 
-from .merge_types import NodeAggregate, LinkedEdgeSummary, SourceMetadata
+from .merge_types import (
+    NodeAggregate,
+    LinkedEdgeSummary,
+    SourceMetadata,
+    NodeAttributesBySource,
+    EdgeAggregate,
+    EdgeAttributesBySource,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +23,7 @@ class MergeIndex(BaseModel):
     """Aggregated, key-addressable view over nodes collected from outputs."""
 
     nodes: Dict[str, NodeAggregate]
+    edges: Dict[str, EdgeAggregate] = Field(default_factory=dict)
 
 
 def _node_key(canonical_name: str) -> str:
@@ -50,6 +58,70 @@ def _summarize_edge(
     )
 
 
+def _upsert_edge_aggregate(
+    aggregates: Dict[str, EdgeAggregate], edge, source: SourceMetadata, target_key: str
+) -> EdgeAggregate:
+    agg = _get_or_create_edge_aggregate(aggregates, edge)
+    _append_edge_global_lists(agg, edge, source, target_key)
+    _upsert_edge_attributes_by_source(agg, edge, source, target_key)
+    return agg
+
+
+def _get_or_create_edge_aggregate(
+    aggregates: Dict[str, EdgeAggregate], edge
+) -> EdgeAggregate:
+    edge_key = edge.type
+    if edge_key in aggregates:
+        return aggregates[edge_key]
+    aggregates[edge_key] = EdgeAggregate(
+        edge_key=edge_key,
+        edge_type=edge.type,
+        text=edge.type,
+        node_pairs=[],
+        rationales=[],
+        confidence_samples=[],
+        sources=[],
+        attributes_by_source=[],
+    )
+    return aggregates[edge_key]
+
+
+def _append_edge_global_lists(
+    agg: EdgeAggregate, edge, source: SourceMetadata, target_key: str
+) -> None:
+    agg.node_pairs.append((f"paper:{source.paper_id}", target_key))
+    agg.rationales.append(edge.rationale)
+    agg.confidence_samples.append(edge.confidence)
+    agg.sources.append(source)
+
+
+def _upsert_edge_attributes_by_source(
+    agg: EdgeAggregate, edge, source: SourceMetadata, target_key: str
+) -> None:
+    sid = source.paper_id
+    for entry in agg.attributes_by_source:
+        if entry.paper_id == sid:
+            _merge_edge_attr_entry(entry, edge, sid, target_key)
+            return
+    agg.attributes_by_source.append(
+        EdgeAttributesBySource(
+            paper_id=sid,
+            doi=getattr(source, "doi", None),
+            node_pairs=[(f"paper:{sid}", target_key)],
+            rationales=[edge.rationale],
+            confidence_samples=[edge.confidence],
+        )
+    )
+
+
+def _merge_edge_attr_entry(
+    entry: EdgeAttributesBySource, edge, sid: str, target_key: str
+) -> None:
+    entry.node_pairs.append((f"paper:{sid}", target_key))
+    entry.rationales.append(edge.rationale)
+    entry.confidence_samples.append(edge.confidence)
+
+
 def _upsert_node_aggregate(
     aggregates: Dict[str, NodeAggregate], node, source: SourceMetadata
 ) -> NodeAggregate:
@@ -60,22 +132,8 @@ def _upsert_node_aggregate(
             return aggregates[key]
 
         agg = aggregates[key]
-        if (
-            node.canonical_name
-            and node.canonical_name.lower() == agg.canonical_text.lower()
-        ):
-            agg.text = node.name
-
-        alias_set = set(agg.aliases)
-        alias_set.update(node.aliases or [])
-        agg.aliases = list(alias_set)
-
-        note_text = getattr(node, "notes", None)
-        if note_text and note_text not in agg.notes:
-            agg.notes.append(note_text)
-        if node.confidence is not None:
-            agg.confidence_samples.append(node.confidence)
-        agg.sources.append(source)
+        _merge_node_aggregate_fields(agg, node, source)
+        _upsert_node_attributes_by_source(agg, node, source)
         return agg
     except Exception as e:
         logger.debug(f"Error upserting node {getattr(node, 'name', 'unknown')}: {e}")
@@ -96,15 +154,90 @@ def _upsert_node_aggregate(
 
 
 def _create_node_aggregate(node, key: str, source: SourceMetadata) -> NodeAggregate:
-    return NodeAggregate(
+    sid = source.paper_id
+    agg = NodeAggregate(
         node_key=key,
         text=node.name,
         canonical_text=node.canonical_name or node.name,
         aliases=list(node.aliases or []),
         notes=[node.notes] if getattr(node, "notes", None) else [],
-        confidence_samples=[node.confidence],
+        confidence_samples=[node.confidence] if node.confidence is not None else [],
         linked_edges=[],
         sources=[source],
+    )
+    _seed_node_attributes_by_source(agg, node, source, sid)
+    return agg
+
+
+def _merge_node_aggregate_fields(
+    agg: NodeAggregate, node, source: SourceMetadata
+) -> None:
+    if (
+        node.canonical_name
+        and node.canonical_name.lower() == agg.canonical_text.lower()
+    ):
+        agg.text = node.name
+    agg.aliases = _merge_alias_lists(agg.aliases, node.aliases or [])
+    note_text = getattr(node, "notes", None)
+    if note_text and note_text not in agg.notes:
+        agg.notes.append(note_text)
+    if node.confidence is not None:
+        agg.confidence_samples.append(node.confidence)
+    agg.sources.append(source)
+
+
+def _merge_alias_lists(existing: List[str], new_aliases: List[str]) -> List[str]:
+    alias_set = set(existing)
+    alias_set.update(new_aliases)
+    return list(alias_set)
+
+
+def _upsert_node_attributes_by_source(
+    agg: NodeAggregate, node, source: SourceMetadata
+) -> None:
+    sid = source.paper_id
+    for entry in agg.attributes_by_source:
+        if entry.paper_id == sid:
+            _merge_node_attr_entry(entry, node, sid)
+            return
+    agg.attributes_by_source.append(
+        NodeAttributesBySource(
+            paper_id=sid,
+            doi=getattr(source, "doi", None),
+            text=node.name,
+            canonical_text=node.canonical_name or node.name,
+            aliases=list(node.aliases or []),
+            notes=[node.notes] if getattr(node, "notes", None) else [],
+            confidence=node.confidence,
+        )
+    )
+
+
+def _merge_node_attr_entry(entry: NodeAttributesBySource, node, sid: str) -> None:
+    entry.text = node.name or entry.text
+    entry.canonical_text = node.canonical_name or entry.canonical_text
+    if node.aliases:
+        entry.aliases = _merge_alias_lists(entry.aliases, list(node.aliases))
+    if getattr(node, "notes", None):
+        if node.notes not in entry.notes:
+            entry.notes.append(node.notes)
+    if node.confidence is not None:
+        entry.confidence = node.confidence
+
+
+def _seed_node_attributes_by_source(
+    agg: NodeAggregate, node, source: SourceMetadata, sid: str
+) -> None:
+    agg.attributes_by_source.append(
+        NodeAttributesBySource(
+            paper_id=sid,
+            doi=getattr(source, "doi", None),
+            text=node.name,
+            canonical_text=node.canonical_name or node.name,
+            aliases=list(node.aliases or []),
+            notes=[node.notes] if getattr(node, "notes", None) else [],
+            confidence=node.confidence,
+        )
     )
 
 
@@ -115,42 +248,98 @@ def build_merge_index(output_dir: Path) -> MergeIndex:
     LinkedEdgeSummary preserves this relationship and is ready for future
     node-to-node edges when the extraction schema evolves.
     """
-    aggregates: Dict[str, NodeAggregate] = {}
+    node_aggregates: Dict[str, NodeAggregate] = {}
+    edge_aggregates: Dict[str, EdgeAggregate] = {}
 
     for json_path in _iter_valid_output_files(output_dir):
-        data = _load_output(json_path)
-        if data is None:
-            continue
+        _process_output_file(json_path, node_aggregates, edge_aggregates)
 
-        source_metadata = SourceMetadata(paper_id=json_path.stem)
+    return MergeIndex(nodes=node_aggregates, edges=edge_aggregates)
 
-        # Process each edge - current schema has paper -> target_node relationships
-        for edge in data.edges:
-            try:
-                target_node = edge.target_node
-                target_key = _node_key(target_node.canonical_name or target_node.name)
 
-                # Current schema: paper is implicit source, target_node is explicit
-                # Future schema could have explicit source_node -> target_node
-                source_key = f"paper:{source_metadata.paper_id}"
+def _process_output_file(
+    json_path: Path,
+    node_aggregates: Dict[str, NodeAggregate],
+    edge_aggregates: Dict[str, EdgeAggregate],
+) -> None:
+    data = _load_output(json_path)
+    if data is None:
+        return
 
-                # Ensure target node aggregate exists
-                target_agg = _upsert_node_aggregate(
-                    aggregates, target_node, source_metadata
-                )
+    source_metadata = _source_from_path(json_path)
 
-                # Create directional edge preserving the paper -> node relationship
-                edge_summary = _summarize_edge(
-                    edge=edge,
-                    source_node_key=source_key,
-                    target_node_key=target_key,
-                    source=source_metadata,
-                )
+    for edge in data.edges:
+        _process_edge_record(
+            edge, source_metadata, node_aggregates, edge_aggregates, json_path
+        )
 
-                # Add to target node's context
-                target_agg.linked_edges.append(edge_summary)
-            except Exception as e:
-                logger.debug(f"Error processing edge in {json_path}: {e}")
+    _add_neighbors_for_paper(data, node_aggregates, json_path)
+
+
+def _process_edge_record(
+    edge,
+    source_metadata: SourceMetadata,
+    node_aggregates: Dict[str, NodeAggregate],
+    edge_aggregates: Dict[str, EdgeAggregate],
+    context_path: Path,
+) -> None:
+    try:
+        target_node = edge.target_node
+        target_key = _node_key(target_node.canonical_name or target_node.name)
+
+        source_key = f"paper:{source_metadata.paper_id}"
+
+        target_agg = _upsert_node_aggregate(
+            node_aggregates, target_node, source_metadata
+        )
+
+        edge_summary = _summarize_edge(
+            edge=edge,
+            source_node_key=source_key,
+            target_node_key=target_key,
+            source=source_metadata,
+        )
+        target_agg.linked_edges.append(edge_summary)
+
+        _upsert_edge_aggregate(edge_aggregates, edge, source_metadata, target_key)
+    except Exception as e:
+        logger.debug(f"Error processing edge in {context_path}: {e}")
+
+
+def _add_neighbors_for_paper(
+    data: OutputSchema,
+    node_aggregates: Dict[str, NodeAggregate],
+    context_path: Path,
+) -> None:
+    try:
+        paper_node_keys = _collect_paper_node_keys(data)
+        unique_keys = list(dict.fromkeys(paper_node_keys))
+        for i, k in enumerate(unique_keys):
+            neighbors = unique_keys[:i] + unique_keys[i + 1 :]
+            agg = node_aggregates.get(k)
+            if not agg:
                 continue
+            neighbor_set = set(agg.neighbor_node_keys)
+            neighbor_set.update(neighbors)
+            agg.neighbor_node_keys = list(neighbor_set)
+    except Exception as e:
+        logger.debug(f"Error building neighbor lists for {context_path}: {e}")
 
-    return MergeIndex(nodes=aggregates)
+
+def _collect_paper_node_keys(data: OutputSchema) -> list[str]:
+    keys: list[str] = []
+    for edge in data.edges:
+        try:
+            keys.append(_target_key_from_node(edge.target_node))
+        except Exception:
+            continue
+    return keys
+
+
+def _source_from_path(json_path: Path) -> SourceMetadata:
+    # TODO: enrich with DOI/title/section when available upstream
+    return SourceMetadata(paper_id=json_path.stem)
+
+
+def _target_key_from_node(node) -> str:
+    return _node_key(node.canonical_name or node.name)

--- a/src/merge_indexer.py
+++ b/src/merge_indexer.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable
+
+from pydantic import BaseModel, ValidationError
+from .prompts import OutputSchema
+
+from .merge_types import NodeAggregate, LinkedEdgeSummary, SourceMetadata
+
+
+class MergeIndex(BaseModel):
+    """Aggregated, key-addressable view over nodes collected from outputs."""
+
+    nodes: Dict[str, NodeAggregate]
+
+
+def _node_key(canonical_name: str) -> str:
+    return canonical_name.strip().lower()
+
+
+def _iter_valid_output_files(output_dir: Path) -> Iterable[Path]:
+    return sorted(p for p in output_dir.glob("*.json") if "raw_response" not in p.name)
+
+
+def _load_output(path: Path) -> OutputSchema | None:
+    try:
+        return OutputSchema.model_validate_json(path.read_text(encoding="utf-8"))
+    except (ValidationError, ValueError):
+        return None
+
+
+def _summarize_edge(edge, source: SourceMetadata) -> LinkedEdgeSummary:
+    return LinkedEdgeSummary(
+        edge_type=edge.type,
+        rationale=edge.rationale,
+        confidence=edge.confidence,
+        source=source,
+    )
+
+
+def _upsert_node_aggregate(
+    aggregates: Dict[str, NodeAggregate], node, source: SourceMetadata
+) -> NodeAggregate:
+    key = _node_key(node.canonical_name or node.name)
+    if key not in aggregates:
+        aggregates[key] = _create_node_aggregate(node=node, key=key, source=source)
+        return aggregates[key]
+
+    agg = aggregates[key]
+    if (
+        node.canonical_name
+        and node.canonical_name.lower() == agg.canonical_text.lower()
+    ):
+        agg.text = node.name
+    for alias in node.aliases or []:
+        if alias not in agg.aliases:
+            agg.aliases.append(alias)
+    note_text = getattr(node, "notes", None)
+    if note_text and note_text not in agg.notes:
+        agg.notes.append(note_text)
+    if node.confidence is not None:
+        agg.confidence_samples.append(node.confidence)
+    agg.sources.append(source)
+    return agg
+
+
+def _create_node_aggregate(node, key: str, source: SourceMetadata) -> NodeAggregate:
+    return NodeAggregate(
+        node_key=key,
+        text=node.name,
+        canonical_text=node.canonical_name or node.name,
+        aliases=list(node.aliases or []),
+        notes=[node.notes] if getattr(node, "notes", None) else [],
+        confidence_samples=[node.confidence],
+        linked_edges=[],
+        sources=[source],
+    )
+
+
+def build_merge_index(output_dir: Path) -> MergeIndex:
+    """Aggregate nodes from validated outputs into a compact index."""
+    aggregates: Dict[str, NodeAggregate] = {}
+
+    for json_path in _iter_valid_output_files(output_dir):
+        data = _load_output(json_path)
+        if data is None:
+            continue
+
+        source = SourceMetadata(paper_id=json_path.stem)
+        for edge in data.edges:
+            agg = _upsert_node_aggregate(aggregates, edge.target_node, source)
+            agg.linked_edges.append(_summarize_edge(edge, source))
+
+    return MergeIndex(nodes=aggregates)

--- a/src/merge_indexer.py
+++ b/src/merge_indexer.py
@@ -57,9 +57,12 @@ def _upsert_node_aggregate(
         and node.canonical_name.lower() == agg.canonical_text.lower()
     ):
         agg.text = node.name
-    for alias in node.aliases or []:
-        if alias not in agg.aliases:
-            agg.aliases.append(alias)
+
+    # Use set operations for efficient deduplication
+    alias_set = set(agg.aliases)
+    alias_set.update(node.aliases or [])
+    agg.aliases = list(alias_set)
+
     note_text = getattr(node, "notes", None)
     if note_text and note_text not in agg.notes:
         agg.notes.append(note_text)

--- a/src/merge_input_builder.py
+++ b/src/merge_input_builder.py
@@ -5,6 +5,7 @@ from .merge_types import (
     NodeViewForComparison,
     NodeAggregate,
     NeighborNodeSummary,
+    NodeSetComparisonInput,
 )
 from .merge_indexer import MergeIndex
 
@@ -21,17 +22,30 @@ def _node_view(agg: NodeAggregate, index: MergeIndex) -> NodeViewForComparison:
         n = index.nodes.get(nk)
         if not n:
             continue
+        # Lightweight neighbor context: neighbor notes + its linked edge rationales
+        neighbor_contexts: list[str] = []
+        for ne in n.linked_edges:
+            if ne.rationale:
+                neighbor_contexts.append(ne.get_context_for_node(n.node_key))
+        if n.notes:
+            neighbor_contexts.extend(n.notes)
         neighbors.append(
-            NeighborNodeSummary(node_key=n.node_key, text=n.text, aliases=n.aliases)
+            NeighborNodeSummary(
+                node_key=n.node_key,
+                text=n.merged_text or n.canonical_text,
+                aliases=n.aliases,
+                context=neighbor_contexts,
+            )
         )
 
     return NodeViewForComparison(
-        text=agg.text,
+        merged_text=agg.merged_text or agg.canonical_text,
         aliases=agg.aliases,
         context=contexts + agg.notes,
-        source_metadata=agg.sources,
         linked_edges=agg.linked_edges,
         neighbors=neighbors,
+        # Carry along full per-source details for merge history awareness
+        merged_sources=agg.merged_sources,
     )
 
 
@@ -41,3 +55,13 @@ def build_node_comparison_input(
     a = index.nodes[key_a]
     b = index.nodes[key_b]
     return NodeComparisonInput(node_a=_node_view(a, index), node_b=_node_view(b, index))
+
+
+def build_node_set_comparison_input(
+    index: MergeIndex, keys: list[str]
+) -> NodeSetComparisonInput:
+    views: list[NodeViewForComparison] = []
+    for k in keys:
+        if k in index.nodes:
+            views.append(_node_view(index.nodes[k], index))
+    return NodeSetComparisonInput(nodes=views)

--- a/src/merge_input_builder.py
+++ b/src/merge_input_builder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from .merge_types import (
+    NodeComparisonInput,
+    NodeViewForComparison,
+    NodeAggregate,
+)
+from .merge_indexer import MergeIndex
+
+
+def _node_view(agg: NodeAggregate) -> NodeViewForComparison:
+    contexts: list[str] = []
+    for e in agg.linked_edges:
+        if e.rationale:
+            contexts.append(f"[{e.edge_type}] {e.rationale}")
+
+    return NodeViewForComparison(
+        text=agg.text,
+        aliases=agg.aliases,
+        context=contexts + agg.notes,
+        source_metadata=agg.sources,
+        linked_edges=agg.linked_edges,
+    )
+
+
+def build_node_comparison_input(
+    index: MergeIndex, key_a: str, key_b: str
+) -> NodeComparisonInput:
+    a = index.nodes[key_a]
+    b = index.nodes[key_b]
+    return NodeComparisonInput(node_a=_node_view(a), node_b=_node_view(b))

--- a/src/merge_input_builder.py
+++ b/src/merge_input_builder.py
@@ -12,7 +12,7 @@ def _node_view(agg: NodeAggregate) -> NodeViewForComparison:
     contexts: list[str] = []
     for e in agg.linked_edges:
         if e.rationale:
-            contexts.append(f"[{e.edge_type}] {e.rationale}")
+            contexts.append(e.get_context_for_node(agg.node_key))
 
     return NodeViewForComparison(
         text=agg.text,

--- a/src/merge_types.py
+++ b/src/merge_types.py
@@ -21,12 +21,23 @@ class SourceMetadata(BaseModel):
 
 
 class LinkedEdgeSummary(BaseModel):
-    """Summarized view of an edge touching a node for LLM context."""
+    """Summarized view of an edge touching a node for LLM context with directionality."""
 
     edge_type: str
     rationale: str
     confidence: float = Field(..., ge=0.0, le=1.0)
+    source_node_key: str = Field(..., description="Key of the source node")
+    target_node_key: str = Field(..., description="Key of the target node")
     source: SourceMetadata
+
+    def get_context_for_node(self, node_key: str) -> str:
+        """Generate contextual description based on node's role in the edge."""
+        if node_key == self.source_node_key:
+            return f"[{self.edge_type} -> {self.target_node_key}] {self.rationale}"
+        elif node_key == self.target_node_key:
+            return f"[{self.source_node_key} -> {self.edge_type}] {self.rationale}"
+        else:
+            return f"[{self.edge_type}] {self.rationale}"  # fallback
 
 
 class NodeAggregate(BaseModel):

--- a/src/merge_types.py
+++ b/src/merge_types.py
@@ -66,8 +66,10 @@ class EdgeAggregate(BaseModel):
     edge_key: str
     edge_type: str
     text: str = Field(..., description="Edge-level description if available")
-    source_nodes: List[str]
-    target_nodes: List[str]
+    node_pairs: List[tuple[str, str]] = Field(
+        default_factory=list,
+        description="List of (source_node_key, target_node_key) tuples preserving exact pairings",
+    )
     rationales: List[str] = Field(default_factory=list)
     confidence_samples: List[float] = Field(default_factory=list)
     sources: List[SourceMetadata] = Field(default_factory=list)
@@ -93,8 +95,9 @@ class NodeComparisonInput(BaseModel):
 
 class EdgeViewForComparison(BaseModel):
     text: str
-    source_nodes: List[str]
-    target_nodes: List[str]
+    node_pairs: List[tuple[str, str]] = Field(
+        description="List of (source_node_key, target_node_key) tuples for this edge type"
+    )
     context: List[str] = Field(default_factory=list)
     source_metadata: List[SourceMetadata]
 


### PR DESCRIPTION
## What
Step 1 - for [LLM-assisted Graph Merging strategy](https://github.com/MartinLeitgab/AISafetyIntervention_LiteratureExtraction/issues/23#issuecomment-3184122438), built on top of this [PR](https://github.com/MartinLeitgab/AISafetyIntervention_LiteratureExtraction/pull/16) for:
- Modular models for data-only LLM comparison payloads: SourceMetadata, LinkedEdgeSummary, NodeAggregate, and comparison views.
- Index builder to aggregate nodes, aliases, notes, linked-edge rationales, and sources from output/*.json.
- Payload builder to produce NodeComparisonInput (two-node, data-only view).
- Runnable walkthrough is available at examples/walkthrough_prepare_llm_input.py.
- Documentation is available at docs/LLM_Assisted_Graph_Merging_Step1.md.

## More details per file
- src/merge_types.py: Pydantic models used to prepare LLM comparison inputs (data-only; no prompts).
- src/merge_indexer.py: Build an in-memory index of nodes with merged context, i.e., MergeIndex by aggregating nodes across outputs (aliases, notes, linked edge rationales, sources); skips non-OutputSchema JSONs.
- src/merge_input_builder.py: Converts two aggregated nodes into a compact NodeComparisonInput with text, aliases, context, sources, and linked edges.
- docs/LLM_Assisted_Graph_Merging_Step1.md: Explains Step 1 goals and how the new modules produce data-only LLM inputs. Includes quick commands to run the walkthrough.
- examples/walkthrough_prepare_llm_input.py: Runnable script that indexes nodes from output/ and generates a two-node, data-only comparison payload (optionally saves to JSON).

## Rationale
- Prepares minimal but sufficient context for LLM MERGE vs KEEP SEPARATE decisions without coupling prompt logic to data models.
- Ensures traceability via source metadata; reduces duplication via node-level aggregation.

## Scope
- Step 1 only. No candidate selection, LLM calls, or merge execution.

## Result
Result example after running walkthrough_prepare_llm_input.py 

node_comparison_example.json
```
{
  "node_a": {
    "text": "sota_llms_high_first_order_false_belief_performance",
    "aliases": [],
    "context": [
      "[REPORTS] Paper reports that GPT-4 and ChatGPT succeed on first-order false belief tasks with high accuracy.",
      "Includes numerical accuracies for GPT-4 and ChatGPT across task variants."
    ],
    "source_metadata": [
      {
        "paper_id": "2307.16513v2",
        "title": null,
        "section": null,
        "paragraph_id": null
      }
    ],
    "linked_edges": [
      {
        "edge_type": "REPORTS",
        "rationale": "Paper reports that GPT-4 and ChatGPT succeed on first-order false belief tasks with high accuracy.",
        "confidence": 0.9,
        "source": {
          "paper_id": "2307.16513v2",
          "title": null,
          "section": null,
          "paragraph_id": null
        }
      }
    ]
  },
  "node_b": {
    "text": "emergent_first_order_deception_in_llms",
    "aliases": [],
    "context": [
      "[REPORTS] Paper reports emergence of deception behavior in LLMs for first-order tasks.",
      "GPT-4 and ChatGPT choose deceptive options at high rates in first-order tasks."
    ],
    "source_metadata": [
      {
        "paper_id": "2307.16513v2",
        "title": null,
        "section": null,
        "paragraph_id": null
      }
    ],
    "linked_edges": [
      {
        "edge_type": "REPORTS",
        "rationale": "Paper reports emergence of deception behavior in LLMs for first-order tasks.",
        "confidence": 0.9,
        "source": {
          "paper_id": "2307.16513v2",
          "title": null,
          "section": null,
          "paragraph_id": null
        }
      }
    ]
  }
}

```

## Notes
- Indexer skips non-OutputSchema JSON files in output/ (e.g., saved examples).
- Feedback and discussions from previous PR can be seen [here](https://github.com/MartinLeitgab/AISafetyIntervention_LiteratureExtraction/pull/34/files#diff-0dde2f2bca1559a268555cedbe8f3bc30f506d025b0a0cafa2ff12132ffc0d1d)

## Further Works
From: [this review](https://github.com/MartinLeitgab/AISafetyIntervention_LiteratureExtraction/pull/34#issuecomment-3189083048):
- [ ] In order to keep merging scalable on a 100k paper intervention graph and also implement recursive merging without processing time disadvantages, I see the need to task the LLM with merging more than only 2 nodes, e.g. up to 100 nodes that have been pregrouped via clustering to belong to one similar topic (see #31 for details). 
- [ ] For enabling recursive merging, we need to generalize the data attributes of each node and edge to array types. I think the main ordering key should be the paper DOI from which each set of data attributes were extracted from originally- i.e. a node showing up in two papers should have arrays in its metadata members and potentially also descriptions, maturity etc, describing what attribute values were extracted from paper A vs which values were extracted from paper B. The same would hold for edges.
